### PR TITLE
Fixed method signatures for Dial()

### DIFF
--- a/modes/pt_socks5/pt_socks5.go
+++ b/modes/pt_socks5/pt_socks5.go
@@ -107,7 +107,7 @@ func clientHandler(target string, termMon *termmon.TermMonitor, name string, con
 		}
 	}
 
-	var dialer func(address string) net.Conn
+	var dialer func(address string) (net.Conn, error)
 
 	// Deal with arguments.
 	switch name {
@@ -160,7 +160,7 @@ func clientHandler(target string, termMon *termmon.TermMonitor, name string, con
 
 	f := dialer
 
-	remote := f(socksReq.Target)
+	remote, err := f(socksReq.Target)
 	if err != nil {
 		log.Errorf("%s(%s) - outgoing connection failed: %s", name, addrStr, log.ElideError(err))
 		socksReq.Reply(socks5.ErrorToReplyCode(err))

--- a/modes/stun_udp/stun_udp.go
+++ b/modes/stun_udp/stun_udp.go
@@ -168,7 +168,7 @@ func dialConn(tracker *ConnTracker, addr string, target string, name string, opt
 		return
 	}
 
-	var f func(address string) net.Conn
+	var f func(address string) (net.Conn, error)
 
 	// Deal with arguments.
 	switch name {
@@ -200,14 +200,14 @@ func dialConn(tracker *ConnTracker, addr string, target string, name string, opt
 	}
 
 	fmt.Println("Dialing ", target)
-	remote := f(target)
-	// if err != nil {
-	// 	fmt.Println("outgoing connection failed", err)
-	// 	log.Errorf("(%s) - outgoing connection failed: %s", target, log.ElideError(err))
-	// 	fmt.Println("Failed")
-	// 	delete(*tracker, addr)
-	// 	return
-	// }
+	remote, err := f(target)
+	if err != nil {
+	 	fmt.Println("outgoing connection failed", err)
+	 	log.Errorf("(%s) - outgoing connection failed: %s", target, log.ElideError(err))
+	 	fmt.Println("Failed")
+	 	delete(*tracker, addr)
+	 	return
+	}
 
 	fmt.Println("Success")
 


### PR DESCRIPTION
Change proxy mode code to use the updated method signatures for Dial().  This fixes a build breaking issue.  Must be merged along with the corresponding pull request in shapeshifter-transports:  https://github.com/OperatorFoundation/shapeshifter-transports/pull/4

See issue: https://github.com/OperatorFoundation/shapeshifter-transports/issues/3