### PR TITLE
Reload the listener if it fails

### DIFF
--- a/modes/stun_udp/stun_udp.go
+++ b/modes/stun_udp/stun_udp.go
@@ -194,7 +194,7 @@ func dialConn(tracker *ConnTracker, addr string, target string, name string, opt
 	(*tracker)[addr] = ConnState{remote, false}
 }
 
-func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (launched bool, listeners []net.Listener) {
+func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (launched bool) {
 	fmt.Println("ServerSetup")
 
 	// Launch each of the server listeners.
@@ -225,24 +225,24 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 		case "Replicant":
 			shargs, aok := args["Replicant"]
 			if !aok {
-				return false, nil
+				return false
 			}
 			//FIXME: This may not be the best way to establish shargs as a string
 			shargsString, err:= options2.CoerceToString(shargs)
 			config, err := transports.ParseArgsReplicantServer(shargsString)
 			if err != nil {
-				return false, nil
+				return false
 			}
 			config.Listen(bindaddr.Addr.String())
 		case "meeklite":
 			args, aok := args["meeklite"]
 			if !aok {
-				return false, nil
+				return false
 			}
 
 			untypedUrl, ok := args["Url"]
 			if !ok {
-				return false, nil
+				return false
 			}
 
 			Url, err := options2.CoerceToString(untypedUrl)
@@ -252,7 +252,7 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 
 			untypedFront, ok := args["front"]
 			if !ok {
-				return false, nil
+				return false
 			}
 
 			front, err2 := options2.CoerceToString(untypedFront)
@@ -265,29 +265,29 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 		case "Dust":
 			shargs, aok := args["Dust"]
 			if !aok {
-				return false, nil
+				return false
 			}
 
 			untypedIdPath, ok := shargs["Url"]
 			if !ok {
-				return false, nil
+				return false
 			}
 			idPath, err := options2.CoerceToString(untypedIdPath)
 			if err != nil {
 				log.Errorf("could not coerce Dust Url to string")
-				return false, nil
+				return false
 			}
 			transport := Dust.NewDustServer(idPath)
 			listen = transport.Listen
 		case "shadow":
 			args, aok := args["shadow"]
 			if !aok {
-				return false, nil
+				return false
 			}
 
 			untypedPassword, ok := args["password"]
 			if !ok {
-				return false, nil
+				return false
 			}
 
 			Password, err := options2.CoerceToString(untypedPassword)
@@ -297,7 +297,7 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 
 			untypedCertString, ok := args["certString"]
 			if !ok {
-				return false, nil
+				return false
 			}
 
 			certString, err2 := options2.CoerceToString(untypedCertString)
@@ -313,13 +313,15 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 			return
 		}
 
-		transportLn := listen(bindaddr.Addr.String())
+		go func() {
+			for {
+				transportLn := listen(bindaddr.Addr.String())
+				log.Infof("%s - registered listener: %s", name, log.ElideAddr(bindaddr.Addr.String()))
+				serverAcceptLoop(name, transportLn, &ptServerInfo)
+				transportLn.Close()
+			}
+		}()
 
-		go serverAcceptLoop(name, transportLn, &ptServerInfo)
-
-		log.Infof("%s - registered listener: %s", name, log.ElideAddr(bindaddr.Addr.String()))
-
-		listeners = append(listeners, transportLn)
 		launched = true
 	}
 

--- a/shapeshifter-dispatcher/shapeshifter-dispatcher.go
+++ b/shapeshifter-dispatcher/shapeshifter-dispatcher.go
@@ -119,7 +119,7 @@ func main() {
 	target := flag.String("target", "", "Specify transport server destination address")
 	flag.Parse()
 
-	if *version != ""{
+	if *version != "" {
 		ptversion = version
 	}
 
@@ -200,7 +200,7 @@ func main() {
 					// launched = transparent_udp.ServerSetup(termMon, *bindAddr, *target)
 
 					ptServerInfo := getServerInfo(bindAddr, options, transportsList, orport, extorport, authcookie)
-					launched, _ = transparent_udp.ServerSetup(ptServerInfo, stateDir, *options)
+					launched = transparent_udp.ServerSetup(ptServerInfo, stateDir, *options)
 				}
 			}
 		} else {
@@ -215,7 +215,7 @@ func main() {
 						log.Errorf("must specify -version and -transports")
 						return
 					}
-					launched, _ = transparent_tcp.ClientSetup(*socksAddr, *target, ptClientProxy, names, *options)
+					launched = transparent_tcp.ClientSetup(*socksAddr, *target, ptClientProxy, names, *options)
 				}
 			} else {
 				log.Infof("%s - initializing server transport listeners", execName)
@@ -223,7 +223,7 @@ func main() {
 					log.Errorf("%s - transparent mode requires a bindaddr", execName)
 				} else {
 					ptServerInfo := getServerInfo(bindAddr, options, transportsList, orport, extorport, authcookie)
-					launched, _ = transparent_tcp.ServerSetup(ptServerInfo, stateDir, *options)
+					launched = transparent_tcp.ServerSetup(ptServerInfo, stateDir, *options)
 				}
 			}
 		}
@@ -248,7 +248,7 @@ func main() {
 					log.Errorf("%s - STUN mode requires a bindaddr", execName)
 				} else {
 					ptServerInfo := getServerInfo(bindAddr, options, transportsList, orport, extorport, authcookie)
-					launched, _ = stun_udp.ServerSetup(ptServerInfo, stateDir, *options)
+					launched = stun_udp.ServerSetup(ptServerInfo, stateDir, *options)
 				}
 			}
 		} else {
@@ -261,11 +261,11 @@ func main() {
 					log.Errorf("must specify -version and -transports")
 					return
 				}
-				launched, _ = pt_socks5.ClientSetup(*socksAddr, ptClientProxy, names, *options)
+				launched = pt_socks5.ClientSetup(*socksAddr, ptClientProxy, names, *options)
 			} else {
 				log.Infof("%s - initializing server transport listeners", execName)
 				ptServerInfo := getServerInfo(bindAddr, options, transportsList, orport, extorport, authcookie)
-				launched, _ = pt_socks5.ServerSetup(ptServerInfo, stateDir, *options)
+				launched = pt_socks5.ServerSetup(ptServerInfo, stateDir, *options)
 			}
 		}
 	}
@@ -282,7 +282,7 @@ func main() {
 		_, _ = io.Copy(ioutil.Discard, os.Stdin)
 		os.Exit(-1)
 	} else {
-		select{}
+		select {}
 	}
 }
 


### PR DESCRIPTION
If the server listner fails don't return and just leave the process hanging
without any workable listener. Let's close the listener and create a new
one so it keeps working.

Remove all unused listeners list from the *Setup functions.