### PR TITLE
Rewrote options parsers

### DIFF
--- a/modes/pt_socks5/pt_socks5.go
+++ b/modes/pt_socks5/pt_socks5.go
@@ -190,7 +190,7 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 			if !aok {
 				return false, nil
 			}
-			
+
 			shargsBytes, err:= json.Marshal(shargs)
 			shargsString := string(shargsBytes)
 			config, err := transports.ParseArgsReplicantServer(shargsString)
@@ -213,12 +213,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 			if !ok {
 				return false, nil
 			}
-			idPath, err := options2.CoerceToString(untypedIdPath)
+			idPathByte, err:= json.Marshal(untypedIdPath)
+			idPathString := string(idPathByte)
 			if err != nil {
 				log.Errorf("could not coerce Dust Url to string")
 				return false, nil
 			}
-			transport := Dust.NewDustServer(idPath)
+			transport := Dust.NewDustServer(idPathString)
 			listen = transport.Listen
 		case "meeklite":
 			args, aok := args["meeklite"]
@@ -231,7 +232,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			Url, err := options2.CoerceToString(untypedUrl)
+			UrlByte, err:= json.Marshal(untypedUrl)
+			UrlString := string(UrlByte)
 			if err != nil {
 				log.Errorf("could not coerce meeklite Url to string")
 			}
@@ -241,12 +243,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			front, err2 := options2.CoerceToString(untypedFront)
+			FrontByte, err2:= json.Marshal(untypedFront)
+			FrontString := string(FrontByte)
 			if err2 != nil {
 				log.Errorf("could not coerce meeklite front to string")
 			}
 			var dialer proxy.Dialer
-			transport := meeklite.NewMeekTransportWithFront(Url, front, dialer)
+			transport := meeklite.NewMeekTransportWithFront(UrlString, FrontString, dialer)
 			listen = transport.Listen
 		case "shadow":
 			args, aok := args["shadow"]
@@ -259,7 +262,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			Password, err := options2.CoerceToString(untypedPassword)
+			passwordByte, err:= json.Marshal(untypedPassword)
+			passwordString := string(passwordByte)
 			if err != nil {
 				log.Errorf("could not coerce shadow password to string")
 			}
@@ -269,12 +273,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			certString, err2 := options2.CoerceToString(untypedCertString)
+			certByte, err2:= json.Marshal(untypedCertString)
+			certString := string(certByte)
 			if err2 != nil {
 				log.Errorf("could not coerce shadow certString to string")
 			}
 
-			transport := shadow.NewShadowServer(Password, certString)
+			transport := shadow.NewShadowServer(passwordString, certString)
 			listen = transport.Listen
 		default:
 			log.Errorf("Unknown transport: %s", name)

--- a/modes/pt_socks5/pt_socks5.go
+++ b/modes/pt_socks5/pt_socks5.go
@@ -30,6 +30,7 @@
 package pt_socks5
 
 import (
+	"encoding/json"
 	"fmt"
 	options2 "github.com/OperatorFoundation/shapeshifter-dispatcher/common"
 	"github.com/OperatorFoundation/shapeshifter-dispatcher/common/pt_extras"
@@ -189,8 +190,9 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 			if !aok {
 				return false, nil
 			}
-			//FIXME: This may not be the best way to establish shargs as a string
-			shargsString, err:= options2.CoerceToString(shargs)
+			
+			shargsBytes, err:= json.Marshal(shargs)
+			shargsString := string(shargsBytes)
 			config, err := transports.ParseArgsReplicantServer(shargsString)
 			if err != nil {
 				return false, nil

--- a/modes/stun_udp/stun_udp.go
+++ b/modes/stun_udp/stun_udp.go
@@ -30,6 +30,7 @@
 package stun_udp
 
 import (
+	"encoding/json"
 	"fmt"
 	options2 "github.com/OperatorFoundation/shapeshifter-dispatcher/common"
 	"github.com/OperatorFoundation/shapeshifter-dispatcher/common/pt_extras"
@@ -227,8 +228,9 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 			if !aok {
 				return false, nil
 			}
-			//FIXME: This may not be the best way to establish shargs as a string
-			shargsString, err:= options2.CoerceToString(shargs)
+
+			shargsBytes, err:= json.Marshal(shargs)
+			shargsString := string(shargsBytes)
 			config, err := transports.ParseArgsReplicantServer(shargsString)
 			if err != nil {
 				return false, nil

--- a/modes/stun_udp/stun_udp.go
+++ b/modes/stun_udp/stun_udp.go
@@ -247,7 +247,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			Url, err := options2.CoerceToString(untypedUrl)
+			urlByte, err:= json.Marshal(untypedUrl)
+			urlString := string(urlByte)
 			if err != nil {
 				log.Errorf("could not coerce meeklite Url to string")
 			}
@@ -257,12 +258,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			front, err2 := options2.CoerceToString(untypedFront)
+			frontByte, err2:= json.Marshal(untypedFront)
+			frontString := string(frontByte)
 			if err2 != nil {
 				log.Errorf("could not coerce meeklite front to string")
 			}
 			var dialer proxy.Dialer
-			transport := meeklite.NewMeekTransportWithFront(Url, front, dialer)
+			transport := meeklite.NewMeekTransportWithFront(urlString, frontString, dialer)
 			listen = transport.Listen
 		case "Dust":
 			shargs, aok := args["Dust"]
@@ -274,12 +276,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 			if !ok {
 				return false, nil
 			}
-			idPath, err := options2.CoerceToString(untypedIdPath)
+			idPathByte, err:= json.Marshal(untypedIdPath)
+			idPathString := string(idPathByte)
 			if err != nil {
 				log.Errorf("could not coerce Dust Url to string")
 				return false, nil
 			}
-			transport := Dust.NewDustServer(idPath)
+			transport := Dust.NewDustServer(idPathString)
 			listen = transport.Listen
 		case "shadow":
 			args, aok := args["shadow"]
@@ -292,7 +295,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			Password, err := options2.CoerceToString(untypedPassword)
+			passwordByte, err:= json.Marshal(untypedPassword)
+			passwordString := string(passwordByte)
 			if err != nil {
 				log.Errorf("could not coerce shadow password to string")
 			}
@@ -302,12 +306,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			certString, err2 := options2.CoerceToString(untypedCertString)
+			certByte, err2:= json.Marshal(untypedCertString)
+			certString := string(certByte)
 			if err2 != nil {
 				log.Errorf("could not coerce shadow certString to string")
 			}
 
-			transport := shadow.NewShadowServer(Password, certString)
+			transport := shadow.NewShadowServer(passwordString, certString)
 			listen = transport.Listen
 
 		default:

--- a/modes/transparent_tcp/transparent_tcp.go
+++ b/modes/transparent_tcp/transparent_tcp.go
@@ -30,6 +30,7 @@
 package transparent_tcp
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	options2 "github.com/OperatorFoundation/shapeshifter-dispatcher/common"
@@ -188,8 +189,9 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 					log.Errorf("Unable to parse Replicant arguments.")
 					return false, nil
 				}
-				//FIXME: This may not be the best way to establish shargs as a string
-				shargsString, err:= options2.CoerceToString(shargs)
+				//FIXME put the below code into the other cases
+				shargsBytes, err:= json.Marshal(shargs)
+				shargsString := string(shargsBytes)
 				config, err := transports.ParseArgsReplicantServer(shargsString)
 				if err != nil {
 					println("Received a Replicant config error: ", err.Error())

--- a/modes/transparent_tcp/transparent_tcp.go
+++ b/modes/transparent_tcp/transparent_tcp.go
@@ -211,12 +211,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 			if !ok {
 				return false, nil
 			}
-			idPath, err := options2.CoerceToString(untypedIdPath)
+			idPathByte, err:= json.Marshal(untypedIdPath)
+			idPathString := string(idPathByte)
 			if err != nil {
 				log.Errorf("could not coerce Dust Url to string")
 				return false, nil
 			}
-			transport := Dust.NewDustServer(idPath)
+			transport := Dust.NewDustServer(idPathString)
 			listen = transport.Listen
 		case "meeklite":
 			args, aok := args["meeklite"]
@@ -229,7 +230,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			Url, err := options2.CoerceToString(untypedUrl)
+			urlByte, err:= json.Marshal(untypedUrl)
+			urlString := string(urlByte)
 			if err != nil {
 				log.Errorf("could not coerce meeklite Url to string")
 			}
@@ -239,12 +241,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			front, err2 := options2.CoerceToString(untypedFront)
+			frontByte, err2:= json.Marshal(untypedFront)
+			frontString := string(frontByte)
 			if err2 != nil {
 				log.Errorf("could not coerce meeklite front to string")
 			}
 			var dialer proxy.Dialer
-			transport := meeklite.NewMeekTransportWithFront(Url, front, dialer)
+			transport := meeklite.NewMeekTransportWithFront(urlString, frontString, dialer)
 			listen = transport.Listen
 		case "shadow":
 			args, aok := args["shadow"]
@@ -257,22 +260,24 @@ func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (l
 				return false, nil
 			}
 
-			Password, err := options2.CoerceToString(untypedPassword)
+			passwordByte, err:= json.Marshal(untypedPassword)
+			passwordString := string(passwordByte)
 			if err != nil {
 				log.Errorf("could not coerce shadow password to string")
 			}
 
-			untypedCipherNameString, ok := args["cipherName"]
+			untypedCertString, ok := args["certString"]
 			if !ok {
 				return false, nil
 			}
 
-			cipherNameString, err2 := options2.CoerceToString(untypedCipherNameString)
+			certByte, err2:= json.Marshal(untypedCertString)
+			certString := string(certByte)
 			if err2 != nil {
 				log.Errorf("could not coerce shadow certString to string")
 			}
 
-			transport := shadow.NewShadowServer(Password, cipherNameString)
+			transport := shadow.NewShadowServer(passwordString, certString)
 			listen = transport.Listen
 		default:
 			log.Errorf("Unknown transport: %s", name)

--- a/modes/transparent_udp/transparent_udp.go
+++ b/modes/transparent_udp/transparent_udp.go
@@ -32,6 +32,7 @@ package transparent_udp
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	options2 "github.com/OperatorFoundation/shapeshifter-dispatcher/common"
 	"github.com/OperatorFoundation/shapeshifter-dispatcher/common/log"
@@ -245,8 +246,9 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 			if !aok {
 				return false, nil
 			}
-			//FIXME: This may not be the best way to establish shargs as a string
-			shargsString, err:= options2.CoerceToString(shargs)
+
+			shargsBytes, err:= json.Marshal(shargs)
+			shargsString := string(shargsBytes)
 			config, err := transports.ParseArgsReplicantServer(shargsString)
 			if err != nil {
 				return false, nil

--- a/modes/transparent_udp/transparent_udp.go
+++ b/modes/transparent_udp/transparent_udp.go
@@ -266,12 +266,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 			if !ok {
 				return false, nil
 			}
-			idPath, err := options2.CoerceToString(untypedIdPath)
+			IdPathByte, err:= json.Marshal(untypedIdPath)
+			IdPathString := string(IdPathByte)
 			if err != nil {
 				log.Errorf("could not coerce Dust Url to string")
 				return false, nil
 			}
-			transport := Dust.NewDustServer(idPath)
+			transport := Dust.NewDustServer(IdPathString)
 			listen = transport.Listen
 		case "meeklite":
 			args, aok := args["meeklite"]
@@ -284,7 +285,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			Url, err := options2.CoerceToString(untypedUrl)
+			UrlByte, err:= json.Marshal(untypedUrl)
+			UrlString := string(UrlByte)
 			if err != nil {
 				log.Errorf("could not coerce meeklite Url to string")
 			}
@@ -294,12 +296,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			front, err2 := options2.CoerceToString(untypedFront)
+			FrontByte, err2:= json.Marshal(untypedFront)
+			FrontString := string(FrontByte)
 			if err2 != nil {
 				log.Errorf("could not coerce meeklite front to string")
 			}
 			var dialer proxy.Dialer
-			transport := meeklite.NewMeekTransportWithFront(Url, front, dialer)
+			transport := meeklite.NewMeekTransportWithFront(UrlString, FrontString, dialer)
 			listen = transport.Listen
 		case "shadow":
 			args, aok := args["shadow"]
@@ -312,7 +315,8 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			Password, err := options2.CoerceToString(untypedPassword)
+			passwordByte, err:= json.Marshal(untypedPassword)
+			passwordString := string(passwordByte)
 			if err != nil {
 				log.Errorf("could not coerce shadow password to string")
 			}
@@ -322,12 +326,13 @@ func ServerSetup(ptServerInfo pt.ServerInfo, stateDir string, options string) (l
 				return false, nil
 			}
 
-			certString, err2 := options2.CoerceToString(untypedCertString)
+			certByte, err2:= json.Marshal(untypedCertString)
+			certString := string(certByte)
 			if err2 != nil {
 				log.Errorf("could not coerce shadow certString to string")
 			}
 
-			transport := shadow.NewShadowServer(Password, certString)
+			transport := shadow.NewShadowServer(passwordString, certString)
 			listen = transport.Listen
 		default:
 			log.Errorf("Unknown transport: %s", name)

--- a/obfs4.json
+++ b/obfs4.json
@@ -1,1 +1,1 @@
-{"cert": "a1cc6eI5H+1kTzXhbuwMR9w3ZkLeZuReniier8DYSlAg4ed9yTbnyDiWc1vF1WFWKFRYHQ", "iat-mode": "0"}
+{"cert": "rpsdofpqFSbaZxAMxSOHbYF+DfoC5ucZxz3jGPLiJ+BAa9P/81jPIRiYecLcoNlCS3bYeQ", "iat-mode": "0"}


### PR DESCRIPTION
option parsers were rewritten to use json struct unmarshalling instead of generic json parsing