### PR TITLE
Fix parameter validation in SOCKS5 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For this example to work, you need an application server running. You can use ne
     
 For compatibility reasons, SOCKS5 mode uses an environment variable to specify the application server address instead of -bindaddr:
 
-    export TOR_PT_SERVER_BINDADDR=127.0.0.1:2222
+    export TOR_PT_SERVER_BINDADDR=Replicant-127.0.0.1:2222
 
 Now launch the transport server, telling it where to find the application server:
 

--- a/main.go
+++ b/main.go
@@ -252,10 +252,12 @@ func main() {
 		}
 
 	} else {
-		serverBindValidationError := validateServerBindAddr(transport, serverBindHost, serverBindPort, bindAddr)
-		if serverBindValidationError != nil {
-			log.Errorf("could not validate: %s",serverBindValidationError)
-			return
+		if (mode != socks5) {
+			serverBindValidationError := validateServerBindAddr(transport, serverBindHost, serverBindPort, bindAddr)
+			if serverBindValidationError != nil {
+				log.Errorf("could not validate: %s",serverBindValidationError)
+				return
+			}
 		}
 
 		if *transport != "" && *serverBindHost != "" && *serverBindPort != "" && *bindAddr == "" {


### PR DESCRIPTION
`validateServerBindAddr` is always getting called, which requires that a valid combination of `--bindaddr`, `--bindhost`, and `--bindport` are set, but those parameters can't be used in SOCKS5 mode. This just skips the parameter validation in SOCKS5 mode, because the `TOR_PT_SERVER_BINDADDR` env var will get validated later in `getServerBindaddrs` anyway.

I also updated the README example so that the env var parses correctly.