### PR TITLE
Socks5 proxy server mode 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,6 +20,7 @@ jobs:
         go install
 
   test:
+    runs-on: ubuntu-latest
     needs: build
     steps:
     - name: Test SocksTCP

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,18 +19,24 @@ jobs:
         sudo apt install -y netcat
         go install
 
+  test:
+    needs: build
+    steps:
     - name: Test SocksTCP
       working-directory: ./shTests/SocksTCP
       run: sh ./runAllSocksTests.sh
 
     - name: Test StunUDP
+      if: always()
       working-directory: ./shTests/StunUDP
       run: sh ./runAllStunUDPTests.sh
     
     - name: Test TransparentTCP
+      if: always()
       working-directory: ./shTests/TransparentTCP
       run: sh ./runAllTCPTests.sh
     
     - name: Test TransparentUDP
+      if: always()
       working-directory: ./shTests/TransparentUDP
       run: sh ./runAllUDPTests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,32 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+    - name: Build
+      run: |
+        apt install -y netcat
+        go install
+
+    - name: Test SocksTCP
+      run: sh ./shTests/SocksTCP/runAllSocksTests.sh
+
+    - name: Test StunUDP
+      run: sh ./shTests/StunUDP/runAllStunUDPTests.sh
+    
+    - name: Test TransparentTCP
+      run: sh ./shTests/TransparentTCP/runAllTCPTests.sh
+    
+    - name: Test TransparentUDP
+      run: sh ./shTests/TransparentUDP/runAllUDPTests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
-  build:
+  build and test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,10 +19,6 @@ jobs:
         sudo apt install -y netcat
         go install
 
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
     - name: Test SocksTCP
       working-directory: ./shTests/SocksTCP
       run: sh ./runAllSocksTests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
-  build and test:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Build
       run: |
-        apt install -y netcat
+        sudo apt install -y netcat
         go install
 
     - name: Test SocksTCP

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,13 +20,17 @@ jobs:
         go install
 
     - name: Test SocksTCP
-      run: sh ./shTests/SocksTCP/runAllSocksTests.sh
+      working-directory: ./shTests/SocksTCP
+      run: sh ./runAllSocksTests.sh
 
     - name: Test StunUDP
-      run: sh ./shTests/StunUDP/runAllStunUDPTests.sh
+      working-directory: ./shTests/StunUDP
+      run: sh ./runAllStunUDPTests.sh
     
     - name: Test TransparentTCP
-      run: sh ./shTests/TransparentTCP/runAllTCPTests.sh
+      working-directory: ./shTests/TransparentTCP
+      run: sh ./runAllTCPTests.sh
     
     - name: Test TransparentUDP
-      run: sh ./shTests/TransparentUDP/runAllUDPTests.sh
+      working-directory: ./shTests/TransparentUDP
+      run: sh ./runAllUDPTests.sh

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/kataras/pio v0.0.10 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/things-go/go-socks5 v0.0.2 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/sys v0.0.0-20220429233432-b5fbb4746d32 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/things-go/go-socks5 v0.0.2 h1:dFi5iZ/LqgHRTQ6n3XlipTLDWHAQsejvJ300bH2VFWo=
+github.com/things-go/go-socks5 v0.0.2/go.mod h1:dhnDTBbIg31cbJdROP4/Zz6Iw7JPEpiMvOl2LdHSSjE=
 github.com/willscott/goturn v0.0.0-20170802220503-19f41278d0c9 h1:yKStnJf2/R4IETsrVlAGBxjBxQ3JgVGnjV3gDlc6tAs=
 github.com/willscott/goturn v0.0.0-20170802220503-19f41278d0c9/go.mod h1:PfwRjodCaQXOsHnh2DeVaXqCFCIrbn5WLj1+A5bQkD4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -49,6 +51,7 @@ golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ const (
 	transparentTCP
 	transparentUDP
 	stunUDP
+	dynamic
 )
 
 func main() {
@@ -100,7 +101,7 @@ func main() {
 	targetPort := flag.String("targetport", "", "Specify transport server destination address host")
 	proxyListenHost := flag.String("proxylistenhost", "", "Specify the bind address for the local SOCKS server host provided by the client")
 	proxyListenPort := flag.String("proxylistenport", "", "Specify the bind address for the local SOCKS server port provided by the client")
-	modeName := flag.String("mode", "", "Specify which mode is being used: transparent-TCP, transparent-UDP, socks5, or STUN")
+	modeName := flag.String("mode", "", "Specify which mode is being used: transparent-TCP, transparent-UDP, socks5, STUN or dynamic")
 
 	// PT 2.1 specification, 3.3.1.2. Pluggable PT Client Configuration Parameters
 	proxy := flag.String("proxy", "", "Specify an HTTP or SOCKS4a proxy that the PT needs to use to reach the Internet")
@@ -329,6 +330,9 @@ func main() {
 		case stunUDP:
 			ptServerInfo := getServerInfo(bindAddr, options, transportsList, target, extorport, authcookie)
 			launched = stun_udp.ServerSetup(ptServerInfo, stateDir, *options)
+		case dynamic:
+			ptServerInfo := getServerInfo(bindAddr, options, transportsList, target, extorport, authcookie)
+			launched = transparent_tcp.ServerProxyServe(ptServerInfo, stateDir, *options)
 		default:
 			golog.Errorf("unsupported mode %d", mode)
 		}
@@ -361,6 +365,8 @@ func determineMode(mode string, isTransparent bool, isUDP bool) (int, error) {
 			return transparentUDP, nil
 		case "STUN":
 			return stunUDP, nil
+		case "dynamic":
+			return dynamic, nil
 		default:
 			return -1, errors.New("invalid mode")
 		}

--- a/modes/transparent_tcp/transparent_tcp.go
+++ b/modes/transparent_tcp/transparent_tcp.go
@@ -31,14 +31,15 @@ package transparent_tcp
 
 import (
 	"fmt"
+	"net"
+	"net/url"
+
 	commonLog "github.com/OperatorFoundation/shapeshifter-dispatcher/common/log"
 	"github.com/OperatorFoundation/shapeshifter-dispatcher/common/pt_extras"
 	"github.com/OperatorFoundation/shapeshifter-dispatcher/modes"
 	pt "github.com/OperatorFoundation/shapeshifter-ipc/v3"
 	"github.com/kataras/golog"
 	"golang.org/x/net/proxy"
-	"net"
-	"net/url"
 )
 
 func ClientSetup(socksAddr string, ptClientProxy *url.URL, names []string, options string) (launched bool) {
@@ -107,6 +108,10 @@ func clientHandler(name string, options string, conn net.Conn, proxyURI *url.URL
 
 func ServerSetup(ptServerInfo pt.ServerInfo, statedir string, options string) (launched bool) {
 	return modes.ServerSetupTCP(ptServerInfo, statedir, options, serverHandler)
+}
+
+func ServerProxyServe(ptServerInfo pt.ServerInfo, statedir string, options string) (launched bool) {
+	return modes.ServerSetupDynamic(ptServerInfo, statedir, options, serverHandler)
 }
 
 func serverHandler(name string, remote net.Conn, info *pt.ServerInfo) {

--- a/reduceMicroformats.go
+++ b/reduceMicroformats.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/kataras/golog"
 )
 
@@ -157,6 +158,8 @@ func validateMode(mode *string, transparent *bool, udp *bool) error {
 		case "transparent-UDP":
 			return nil
 		case "STUN":
+			return nil
+		case "dynamic":
 			return nil
 		default:
 			return errors.New("invalid mode")

--- a/shTests/SocksTCP/socks_TCP_test.go
+++ b/shTests/SocksTCP/socks_TCP_test.go
@@ -65,7 +65,7 @@ func TestSocksTCPShadow(t *testing.T) {
 	}
 }
 
-func SocksTCPStarbridge(t *testing.T) {
+func TestSocksTCPStarbridge(t *testing.T) {
 	negotiateError := negotiateSocks("../../ConfigFiles/StarbridgeClientConfig.json")
 	if negotiateError != nil {
 		t.Fail()

--- a/shTests/SocksTCP/socks_TCP_test.go
+++ b/shTests/SocksTCP/socks_TCP_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	socks "github.com/OperatorFoundation/shapeshifter-dispatcher/common/socks5"
 	"io/ioutil"
 	"net"
 	"testing"
 	"time"
+
+	socks "github.com/OperatorFoundation/shapeshifter-dispatcher/common/socks5"
 )
 
 const (
@@ -59,6 +60,13 @@ func TestSocksTCPReplicant(t *testing.T) {
 
 func TestSocksTCPShadow(t *testing.T) {
 	negotiateError := negotiateSocks("../../ConfigFiles/shadowClient.json")
+	if negotiateError != nil {
+		t.Fail()
+	}
+}
+
+func SocksTCPStarbridge(t *testing.T) {
+	negotiateError := negotiateSocks("../../ConfigFiles/StarbridgeClientConfig.json")
 	if negotiateError != nil {
 		t.Fail()
 	}

--- a/shTests/SocksTCP/testSocksTCPOptimizerFirst.sh
+++ b/shTests/SocksTCP/testSocksTCPOptimizerFirst.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPOptimizerFirstOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPOptimizerMinimizeDialDuration.sh
+++ b/shTests/SocksTCP/testSocksTCPOptimizerMinimizeDialDuration.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPOptimizerMinimizeDialDurationOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPOptimizerRandom.sh
+++ b/shTests/SocksTCP/testSocksTCPOptimizerRandom.sh
@@ -2,8 +2,6 @@
 # This script runs a full end-to-end functional test of the dispatcher and the Replicant transportOptimizer transport with the Random Strategy. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPOptimizerRandomOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -14,14 +12,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -bindaddr shadow-127.0.0.1:2222 -target 127.0.0.1:3333 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -bindaddr Replicant-127.0.0.1:2224 -target 127.0.0.1:3333 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -bindaddr shadow-127.0.0.1:2222 -target 127.0.0.1:3333 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -bindaddr Replicant-127.0.0.1:2224 -target 127.0.0.1:3333 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPOptimizerRotate.sh
+++ b/shTests/SocksTCP/testSocksTCPOptimizerRotate.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPOptimizerRotateOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPOptimizerTrack.sh
+++ b/shTests/SocksTCP/testSocksTCPOptimizerTrack.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPOptimizerTrackOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Starbridge-127.0.0.1:2223 -transports Starbridge -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr Replicant-127.0.0.1:2224 -transports Replicant -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPReplicant.sh
+++ b/shTests/SocksTCP/testSocksTCPReplicant.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPReplicantOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPShadow.sh
+++ b/shTests/SocksTCP/testSocksTCPShadow.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPShadowOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 

--- a/shTests/SocksTCP/testSocksTCPShadow.sh
+++ b/shTests/SocksTCP/testSocksTCPShadow.sh
@@ -13,12 +13,12 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -bindaddr shadow-127.0.0.1:2222 -transports shadow -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/SocksTCP/testSocksTCPStarbridge.sh
+++ b/shTests/SocksTCP/testSocksTCPStarbridge.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testSocksTCPStarbridgeOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPOptimizerFirst.sh
+++ b/shTests/StunUDP/testStunUDPOptimizerFirst.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPOptimizerFirstOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPOptimizerMinimizeDialDuration.sh
+++ b/shTests/StunUDP/testStunUDPOptimizerMinimizeDialDuration.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPOptimizerMinimizeDialDurationOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPOptimizerRandom.sh
+++ b/shTests/StunUDP/testStunUDPOptimizerRandom.sh
@@ -2,8 +2,6 @@
 # This script runs a full end-to-end functional test of the dispatcher and the Replicant transportOptimizer transport with the Random Strategy. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPOptimizerRandomOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -14,14 +12,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPOptimizerRotate.sh
+++ b/shTests/StunUDP/testStunUDPOptimizerRotate.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPOptimizerRotateOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPOptimizerTrack.sh
+++ b/shTests/StunUDP/testStunUDPOptimizerTrack.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPOptimizerTrackOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPReplicant.sh
+++ b/shTests/StunUDP/testStunUDPReplicant.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPReplicantOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPShadow.sh
+++ b/shTests/StunUDP/testStunUDPShadow.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPShadowOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/StunUDP/testStunUDPStarbridge.sh
+++ b/shTests/StunUDP/testStunUDPStarbridge.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testStunUDPStarbridgeOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -udp -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -udp -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPOptimizerFirst.sh
+++ b/shTests/TransparentTCP/testTCPOptimizerFirst.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPOptimizerFirstOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPOptimizerMinimizeDialDuration.sh
+++ b/shTests/TransparentTCP/testTCPOptimizerMinimizeDialDuration.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPOptimizerMinimizeDialDurationOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPOptimizerRandom.sh
+++ b/shTests/TransparentTCP/testTCPOptimizerRandom.sh
@@ -2,8 +2,6 @@
 # This script runs a full end-to-end functional test of the dispatcher and the Replicant transportOptimizer transport with the Random Strategy. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPOptimizerRandomOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -14,14 +12,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPOptimizerRotate.sh
+++ b/shTests/TransparentTCP/testTCPOptimizerRotate.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPOptimizerRotateOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPOptimizerTrack.sh
+++ b/shTests/TransparentTCP/testTCPOptimizerTrack.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPOptimizerTrackOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPReplicant.sh
+++ b/shTests/TransparentTCP/testTCPReplicant.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPReplicantOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,13 +13,13 @@ rm $FILENAME
 nc -l 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
 
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPShadow.sh
+++ b/shTests/TransparentTCP/testTCPShadow.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPShadowOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm shTests/TransparentTCP/$FILENAME
 nc -l 3333 >shTests/TransparentTCP/$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentTCP/testTCPStarbridge.sh
+++ b/shTests/TransparentTCP/testTCPStarbridge.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testTCPStarbridgeOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -16,13 +14,13 @@ nc -l 3333 >$FILENAME &
 
 # Run the transport server
 
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
 
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPOptimizerFirst.sh
+++ b/shTests/TransparentUDP/testUDPOptimizerFirst.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPOptimizerFirstOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerFirst.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPOptimizerMinimizeDialDuration.sh
+++ b/shTests/TransparentUDP/testUDPOptimizerMinimizeDialDuration.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPOptimizerMinimizeDialDurationOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerMinimizeDialDuration.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPOptimizerRandom.sh
+++ b/shTests/TransparentUDP/testUDPOptimizerRandom.sh
@@ -2,8 +2,6 @@
 # This script runs a full end-to-end functional test of the dispatcher and the Replicant transportOptimizer transport with the Random Strategy. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPOptimizerRandomOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -14,14 +12,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRandom.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPOptimizerRotate.sh
+++ b/shTests/TransparentUDP/testUDPOptimizerRotate.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPOptimizerRotateOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerRotate.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPOptimizerTrack.sh
+++ b/shTests/TransparentUDP/testUDPOptimizerTrack.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPOptimizerTrackOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,14 +13,14 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2223 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2224 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 5
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Optimizer -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/OptimizerTrack.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPReplicant.sh
+++ b/shTests/TransparentUDP/testUDPReplicant.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPReplicantOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Replicant -bindaddr Replicant-127.0.0.1:2222 -optionsFile ../../ConfigFiles/ReplicantServerConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Replicant -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/ReplicantClientConfigV3.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPShadow.sh
+++ b/shTests/TransparentUDP/testUDPShadow.sh
@@ -3,8 +3,6 @@
 # An alternative way to run this test is to run each command in its own terminal. Each netcat instance can be used to type content which should appear in the other.
 FILENAME=testUDPShadowOutput.txt
 
-GOPATH=${GOPATH:-'$HOME/go'}
-
 # Update and build code
 go install
 
@@ -15,12 +13,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports shadow -bindaddr shadow-127.0.0.1:2222 -optionsFile ../../ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 

--- a/shTests/TransparentUDP/testUDPStarbridge.sh
+++ b/shTests/TransparentUDP/testUDPStarbridge.sh
@@ -12,12 +12,12 @@ rm $FILENAME
 nc -l -u 3333 >$FILENAME &
 
 # Run the transport server
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -server -state state -target 127.0.0.1:3333 -transports Starbridge -bindaddr Starbridge-127.0.0.1:2222 -optionsFile ../../ConfigFiles/StarbridgeServerConfig.json -logLevel DEBUG -enableLogging &
 
 sleep 1
 
 # Run the transport client
-"$GOPATH"/bin/shapeshifter-dispatcher -transparent -udp -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
+shapeshifter-dispatcher -transparent -udp -client -state state -transports Starbridge -proxylistenaddr 127.0.0.1:1443 -optionsFile ../../ConfigFiles/StarbridgeClientConfig.json -logLevel DEBUG -enableLogging &
 sleep 1
 
 # Run a demo application client with netcat


### PR DESCRIPTION
Add a server socks5 proxy mode. The client side keeps using the transparent TCP mode.

## Usage Example:

- Server side command
```
./shapeshifter-dispatcher -mode dynamic -server -state state -transports shadow -bindaddr shadow-123.123.123.123:2222 -optionsFile ConfigFiles/shadowServer.json -logLevel DEBUG -enableLogging
```
Please note, make sure the IP address `123.123.123.123` is public avaiable

- Client side command (same as TCP transparent mode)
```
./shapeshifter-dispatcher -transparent -client -state state -transports shadow -proxylistenaddr 127.0.0.1:1443 -optionsFile ConfigFiles/shadowClient.json -logLevel DEBUG -enableLogging
```

both `shadowServer.json` and `shadowClient.json` files are copied from this repo. Except using the real IP address of the server in `ConfigFiles/shadowClient.json`

## Implementation status
- The organization of the code change isn't optimized, the priority is to show the proof of concept
- Please see more discussion at the parent issue https://github.com/OperatorFoundation/shapeshifter-dispatcher/issues/43
- The branch is based on https://github.com/OperatorFoundation/shapeshifter-dispatcher/pull/42 